### PR TITLE
Improve on a few window / field focus situations

### DIFF
--- a/qhangups/conversations.py
+++ b/qhangups/conversations.py
@@ -43,13 +43,14 @@ class QHangupsConversations(QtGui.QDialog, Ui_QHangupsConversations):
         """Add conversation tab (if not present) and optionally switch to it"""
         conv_widget = self.get_conv_widget(conv_id)
         conv_widget_id = self.conversationsTabWidget.indexOf(conv_widget)
-
         if switch:
             self.conversationsTabWidget.setCurrentWidget(conv_widget)
 
     def on_tab_current_changed(self, conv_widget_id):
         """Current tab changed (callback)"""
+        self.activateWindow()
         conv_widget = self.conversationsTabWidget.widget(conv_widget_id)
+        conv_widget.focus_message_text()
         if conv_widget:
             conv_widget.set_active()
 

--- a/qhangups/conversationwidget.py
+++ b/qhangups/conversationwidget.py
@@ -184,6 +184,10 @@ class QHangupsConversationWidget(QtGui.QWidget, Ui_QHangupsConversationWidget):
         finally:
             self.messageTextEdit.setEnabled(True)
             self.sendButton.setEnabled(True)
+            self.focus_message_text()
+
+    def focus_message_text(self):
+        self.messageTextEdit.setFocus();
 
     def on_disconnect(self):
         """Show that Hangups has disconnected from server (callback)"""


### PR DESCRIPTION
Let's try to improve on how focus is handled a little bit:
- Should refocus the message text input upon message send
- Should focus the message window and message text input any time a conversation tab is opened (e.g. when double clicking on a conversation)
