### PR TITLE
simple fix for text color when using a theme with a dark background

### DIFF
--- a/qhangups/conversationwidget.py
+++ b/qhangups/conversationwidget.py
@@ -100,6 +100,7 @@ class QHangupsConversationWidget(QtWidgets.QWidget, Ui_QHangupsConversationWidge
         self.messagesWebView.setContextMenuPolicy(QtCore.Qt.NoContextMenu)
         self.messagesWebView.page().setLinkDelegationPolicy(QtWebKitWidgets.QWebPage.DelegateAllLinks)
         #self.messagesWebView.settings().setAttribute(QtWebKit.QWebSettings.LocalContentCanAccessRemoteUrls, True)
+        lightness = self.messagesWebView.palette().color(QtGui.QPalette.Background).lightnessF()
         self.messagesWebView.setHtml(
             """<!doctype html>
             <html lang="en">
@@ -107,7 +108,9 @@ class QHangupsConversationWidget(QtWidgets.QWidget, Ui_QHangupsConversationWidge
                 <meta charset="utf-8">
                 <title>Messages</title>
                 <style>
-                    html { font-family: sans-serif; font-size: 10pt; }
+                    html { font-family: sans-serif; font-size: 10pt;"""
+            + ("color: white;" if lightness < 0.2 else "")
+            + """}
                     div.message { margin-bottom: 1em; }
                 </style>
             </head>


### PR DESCRIPTION
This is a very simple fix for #9.
It just checks the lightness of the background color, and if it is below a certain threshold it changes the font color to white.
YMMV
